### PR TITLE
Run Deploy As UID w/ volume

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: broken-reg
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: broken-reg
           image: quay.io/dcaravel/brokenreg:latest
@@ -38,11 +42,17 @@ spec:
               value: "/etc/ssl/docker/tls.crt"
             - name: KEY_FILE
               value: "/etc/ssl/docker/tls.key"
+            - name: BLOB_DIR
+              value: "/brokenregcache"
           volumeMounts:
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
+            - mountPath: /brokenregcache
+              name: cache-vol
       volumes:
         - name: tls-cert
           secret:
             secretName: tls-cert
+        - name: cache-vol
+          emptyDir: {}


### PR DESCRIPTION
`default` service account must have `nonroot` SCC:

```
oc adm policy add-scc-to-user nonroot system:serviceaccount:broken-image-reg:default
```